### PR TITLE
Bugfix: added array and fixed indentation for add_numbers() func

### DIFF
--- a/git_tutorial.py
+++ b/git_tutorial.py
@@ -1,6 +1,6 @@
 def add_numbers(a, b, c):
     """Return the sum of three numbers."""
-     return sum(a, b, c)
+    return sum([a, b, c])
 
 # 1. extend_add numbers to allow an arbitrary number of parameters
 # 2. investigate and resolve security exploit of add_numbers()


### PR DESCRIPTION
edited `def add_numbers(a, b, c):` function's return statement from `return sum(a, b, c)` to `return sum([a, b, c])`. 

Specifically,
* Wrapped the `a, b, c` parameters in `[],` creating an array which is necessary for the `sum()` function to work accurately.
* Also fixed the indentation of the `return` statement, as it was not correctly aligned.